### PR TITLE
fix: Update properties.java to use pure ascii

### DIFF
--- a/properties.java
+++ b/properties.java
@@ -4,6 +4,7 @@
 //DEPS org.jline:jline:3.16.0
 
 import de.vandermeer.asciitable.*;
+import de.vandermeer.asciithemes.a7.A7_Grids;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Parameters;
@@ -37,6 +38,7 @@ class properties implements Callable<Integer> {
         int[] maxkey = { 0 };
 
         AsciiTable at = new AsciiTable();
+        at.getContext().setGrid(A7_Grids.minusBarPlusEquals());
 
         at.addRule();
         at.addRow("Key", "Value");


### PR DESCRIPTION
Sets the ASCII table to use ASCII characters instead of Windows codepage
extensions. As a result, the table now looks like:

+-----------------------------+----------------------------------+
|Key                          |Value                             |
+-----------------------------+----------------------------------+
|awt.toolkit                  |sun.awt.X11.XToolkit              |
|file.encoding                |ANSI_X3.4-1968                    |
:                             :                                  :
+-----------------------------+----------------------------------+