### PR TITLE
Create renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>jbanghub/.github"
+  ]
+}


### PR DESCRIPTION
I think the scripts here should automatically be updated. This would prevent that contributors need to update dependencies by themselves (https://github.com/jbangdev/jbang-catalog/pull/45).

With [Forking Renovate GitHub App](https://github.com/apps/forking-renovate), it should be no-risk to have renovate activated.

Future work: Add `build` to all scripts. (Either "manually" for by the GitHub action - https://github.com/jbangdev/jbang-action/issues/45)

This refs https://github.com/jbangdev/jbang/issues/1548