### PR TITLE
fix: renamed alias git to jgit

### DIFF
--- a/jbang-catalog.json
+++ b/jbang-catalog.json
@@ -20,7 +20,7 @@
       "script-ref": "gavsearch.java",
       "description": "`gavsearch` lets you use search.maven.org from command line.\nExample: `gavsearch hibernate` will search for artifacts with hibernate in its name.\nYou can use any of the search modifiers search.maven.org supports, i.e.:\n`gavsearch c:QuarkusTest` will search for artifacts with class `QuarkusTest`"
     },
-    "git": {
+    "jgit": {
       "script-ref": "jgit.java",
       "description": "Git command line tool implemented with jgit. Lets you do basic git features without installing git!"
     },


### PR DESCRIPTION
It is somewhat confusing to run git@jbangdev because we are using jgit and it does not have all the functionality of git itself. Better to make this clear and call the alias "jgit@jbangdev".